### PR TITLE
Remove stanbondsa.com.au false positive

### DIFF
--- a/resources/domains/s.json
+++ b/resources/domains/s.json
@@ -4153,7 +4153,6 @@
     "stamberg.nl",
     "stampsprint.com",
     "stanastroo.ml",
-    "stanbondsa.com.au",
     "standbildes.ml",
     "standrewswide.co.uk",
     "standupright.com",


### PR DESCRIPTION
## What changed

Removed `stanbondsa.com.au` from `resources/domains/s.json`.

## Why

This is a false positive. Stan Bond is an established Australian business using this domain for ordinary, long-lived business email. The domain has an active public website and its MX records point to Google Workspace (`aspmx.l.google.com` and Google backup MX hosts); it does not provide temporary or disposable mailboxes.

Stop Forum Spam's [current domain report](https://www.stopforumspam.com/domain/stanbondsa.com.au) says the domain does not appear in its database. The only remaining historical statistics are 23 reports clustered between 11 May and 16 June 2012, with no later activity.

The stale classification is causing legitimate users of the domain to be rejected by signup forms that consume disposable-domain lists.

## Validation

- The diff changes only `resources/domains/s.json` and removes exactly one entry.
- The JSON parses successfully after the change.
- `stanbondsa.com.au` is no longer present in the source file.
- Live website check returns HTTP 200.
- Current MX, SPF and DMARC records confirm an actively managed Google Workspace business domain.
